### PR TITLE
Add protocol documentation for ErrUnpromptedPong

### DIFF
--- a/content/documentation/internals/nats-protocol.md
+++ b/content/documentation/internals/nats-protocol.md
@@ -238,7 +238,7 @@ Deliver the same message along with a reply inbox:
 
 ### Description
 
-`PING` and `PONG` implement a simple keep-alive mechanism between client and server. Once a client establishes a connection to the NATS server, the server will continuously send `PING` messages to the client at a configurable interval. If the client fails to respond with a `PONG` message within the configured response interval, the server will terminate its connection. If your connection stays idle for too long, it is cut off:
+`PING` and `PONG` implement a simple keep-alive mechanism between client and server. Once a client establishes a connection to the NATS server, the server will continuously send `PING` messages to the client at a configurable interval. If the client fails to respond to each `PING` with a `PONG` message within the configured response interval, the server will terminate its connection:
 
 ```
 telnet demo.nats.io 4222
@@ -254,6 +254,8 @@ Connection closed by foreign host.
 ```
 
 If the server sends a ping request, you can reply with a pong message to notify the server that you are still interested. You can also ping the server and will receive a pong reply. The ping/pong interval is configurable.
+
+If the client sends a `PONG` message but the server did not send a ping request for it, the client will be disconnected.
 
 ## <a name="OKERR"></a>+OK/ERR
 

--- a/content/documentation/internals/nats-protocol.md
+++ b/content/documentation/internals/nats-protocol.md
@@ -271,11 +271,12 @@ Handling of these errors usually has to be done asynchronously.
 
 Protocol error messages which close the connection:
 
-- `-ERR 'Unknown Protocol Operation'`: Unknown protocol error
+- `-ERR 'Unknown Protocol Operation'`: Unknown protocol error.
 - `-ERR 'Authorization Violation'`: Client failed to authenticate to the server with credentials specified in the [CONNECT](#CONNECT) message.
-- `-ERR 'Authorization Timeout'`: Client took too long to authenticate to the server after establishing a connection (default 1 second)
-- `-ERR 'Parser Error'`: Cannot parse the protocol message sent by the client
+- `-ERR 'Authorization Timeout'`: Client took too long to authenticate to the server after establishing a connection (default 1 second).
+- `-ERR 'Parser Error'`: Cannot parse the protocol message sent by the client.
 - `-ERR 'Stale Connection'`: PING/PONG interval expired.
+- `-ERR 'Received PONG without a pending PING'`: Client sent a PONG while there were no pending PINGs.
 - `-ERR 'Slow Consumer'`: The server pending data size for the connection has reached the maximum size (default 10MB).
 - `-ERR 'Maximum Payload Exceeded'`: Client attempted to publish a message with a payload size that exceeds the `max_payload` size configured on the server. This value is supplied to the client upon connection in the initial [`INFO`](#INFO) message. The client is expected to do proper accounting of byte size to be sent to the server in order to handle this error synchronously.
 


### PR DESCRIPTION
ErrUnpromptedPong gives a new `-ERR` message which comes before a connection close.

This change is in direct response to PR https://github.com/nats-io/gnatsd/pull/218 which addresses Issue https://github.com/nats-io/gnatsd/issues/168